### PR TITLE
Allow the use of a preview.php template

### DIFF
--- a/lib/lab.php
+++ b/lib/lab.php
@@ -67,33 +67,6 @@ class Lab {
     return url($this->path());
   }
 
-  public function current() {
-
-    // Retrieve the first argument of current route wich represents the
-    // relative path
-    $args = kirby()->route()->arguments();
-    $path = a::first($args);
-
-    // Strip the current mode from the path so we get the requested
-    // file/directory
-    if (str::endsWith($path, '/' . lab::$mode)) {
-      $path = substr_replace($path, '', strlen($path) - strlen('/' . lab::$mode));
-    }
-
-    // Distinguish between a file or a pattern directory given as path argument
-    $root = !is_dir($this->root . DS . $path) ? dirname($path) : $path;
-
-    // Ensure a pattern with the given path exists before returning the reference
-    $pattern = new Pattern($root);
-
-    if (!$pattern->exists()) {
-      return false;
-    }
-
-    return $pattern;
-
-  }
-
   public function run($path = '/') {
 
     if($this->kirby->option('patterns.lock') && !$this->kirby->site()->user()) {
@@ -179,7 +152,7 @@ class Lab {
           $config  = $pattern->config();
 
           try {
-            $html = $pattern->render();
+            $html = $pattern->preview();
           } catch(Exception $e) {
             $html = '';
           }
@@ -317,7 +290,7 @@ class Lab {
 
           try {
             lab::$mode = 'preview';
-            $pattern->render();
+            $pattern->preview();
             $data['content'] = '<iframe src="' . $pattern->url() . '/preview"></iframe>';
           } catch(Exception $e) {
             $data['content'] = $this->error($e);

--- a/lib/pattern.php
+++ b/lib/pattern.php
@@ -119,14 +119,8 @@ class Pattern {
 
   }
 
-  public function isOpen($path = null) {
-
-    if (is_null($path) && ($pattern = $this->lab->current())) {
-      $path = $pattern->path();
-    }
-
+  public function isOpen($path) {
     return ( $path == $this->path ) || str::startsWith($path, $this->path);
-
   }
 
   public function children() {

--- a/lib/pattern.php
+++ b/lib/pattern.php
@@ -73,14 +73,18 @@ class Pattern {
   }
 
   public function template() {
+    return tpl::load($this->file('html.php'), $this->data());
+  }
 
-    $tpl = $this->file('html.php');
+  public function preview() {
 
-    if (('preview' === lab::$mode) && $this->isOpen() && file_exists($this->file('preview.php'))) {
-      $tpl = $this->file('preview.php');
+    $file = $this->file('preview.php');
+
+    if (file_exists($file)) {
+      return tpl::load($file, $this->data());
     }
 
-    return tpl::load($tpl, $this->data());
+    return $this->render();
 
   }
 

--- a/lib/pattern.php
+++ b/lib/pattern.php
@@ -27,7 +27,7 @@ class Pattern {
     $this->data = $data;
   }
 
-  public function file($ext) {    
+  public function file($ext) {
     return $this->root . DS . $this->name . '.' . $ext;
   }
 
@@ -73,7 +73,15 @@ class Pattern {
   }
 
   public function template() {
-    return tpl::load($this->file('html.php'), $this->data());
+
+    $tpl = $this->file('html.php');
+
+    if (('preview' === lab::$mode) && $this->isOpen() && file_exists($this->file('preview.php'))) {
+      $tpl = $this->file('preview.php');
+    }
+
+    return tpl::load($tpl, $this->data());
+
   }
 
   public function render() {
@@ -107,16 +115,18 @@ class Pattern {
 
   }
 
-  public function isOpen($path) {
-    if($path == $this->path) {
-      return true;
-    } else if(str::startsWith($path, $this->path)) {
-      return true;
+  public function isOpen($path = null) {
+
+    if (is_null($path) && ($pattern = $this->lab->current())) {
+      $path = $pattern->path();
     }
+
+    return ( $path == $this->path ) || str::startsWith($path, $this->path);
+
   }
 
   public function children() {
-    
+
     $children = new Collection;
 
     foreach(dir::read($this->root) as $dir) {


### PR DESCRIPTION
Sometimes it can be helpful to provide different markup for the pattern
library than using in the site. For example you may want to display
different button stylings, but do not want to move each style into a
separate pattern. With a button.preview.php you can now customize the
preview of your button pattern, while keeping your original markup in
button.html.php. References #5.
