### PR TITLE
Implement callbacks for assets options

### DIFF
--- a/lib/lab.php
+++ b/lib/lab.php
@@ -157,12 +157,19 @@ class Lab {
             $html = '';
           }
 
+          $css = $this->kirby->option('patterns.preview.css', 'assets/css/index.css');
+          $js  = $this->kirby->option('patterns.preview.js', 'assets/js/index.js');
+
+          // callbacks for css and js
+          if(is_callable($css)) $css = call($css, $pattern);
+          if(is_callable($js))  $js  = call($js, $pattern);
+
           return $this->view('views/preview', [
             'pattern'    => $pattern,
             'html'       => $html,
             'background' => a::get($config, 'background', $this->kirby->option('patterns.preview.background')),
-            'css'        => $this->kirby->option('patterns.preview.css', 'assets/css/index.css'),
-            'js'         => $this->kirby->option('patterns.preview.js', 'assets/js/index.js')
+            'css'        => $css,
+            'js'         => $js
           ]);
 
         }

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,16 @@ You can load multiple CSS files by passing an array of files:
 c::set('patterns.preview.css', ['assets/css/main.css', 'assets/css/theme.css']);
 ```
 
+If you need to decide on the CSS file(s) to use for preview dynamically per pattern, you can also use a callback that receives the pattern object:
+
+```php
+c::set('patterns.preview.css', function($pattern) {
+  $name = (str::startsWith($pattern->path(), 'test/'))? 'test' : 'main';
+  
+  return ['assets/css/' . $name . '.css', 'assets/css/theme.css'];
+});
+```
+
 ### patterns.preview.js
 
 Use this option to set where the final JS for your patterns is located. All the specified JS files will be loaded in the preview screen (in the footer) in order to apply behaviour to your patterns. By default the Patterns interface is looking for a `/assets/js/index.js` file.
@@ -69,6 +79,16 @@ You can load multiple JS files by passing an array of files:
 
 ```php
 c::set('patterns.preview.js', ['assets/js/jquery.js', 'assets/js/patterns.js']);
+```
+
+If you need to decide on the JS file(s) to use for preview dynamically per pattern, you can also use a callback that receives the pattern object:
+
+```php
+c::set('patterns.preview.js', function($pattern) {
+  $name = (str::startsWith($pattern->path(), 'test/'))? 'test' : 'main';
+  
+  return ['assets/js/jquery.js', 'assets/js/' . $name . '.js'];
+});
 ```
 
 ### patterns.preview.background


### PR DESCRIPTION
Helpful if there needs to be a different CSS or JS file for different patterns. The callback will get the pattern object and can return pattern-specific asset path(s).
